### PR TITLE
Don't use deprecated apt-get --force-yes

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -126,8 +126,9 @@ for PACKAGE in $PACKAGES; do
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
     topic "Fetching .debs for $PACKAGE"
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall $PACKAGE | indent
-  fi
+    apt-get $APT_OPTIONS -y --allow-downgrades --allow-remove-essential --allow-change-held-packages -d install --reinstall $PACKAGE | indent
+
+fi
 done
 
 mkdir -p $BUILD_DIR/.apt


### PR DESCRIPTION
Identical issue found in https://github.com/jontewks/puppeteer-heroku-buildpack, so this uses the same fix as in that repo